### PR TITLE
Attempt to add separate badges for Ubuntu / MacOS build by splitting workflows.

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -1,0 +1,20 @@
+name: MacOS
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  Build:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Ubuntu
 
 on:
   push:
@@ -14,14 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Build
-      run: cargo build
-    - name: Run tests
-      run: cargo test --verbose
-  MacOS:
-    runs-on: macos-latest
-    steps:
-    - uses: actions/checkout@v2
     - name: Build
       run: cargo build
     - name: Run tests

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -10,7 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  Ubuntu:
+  Build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # PMD-mask
 
 Perform hard selective masking of ancient DNA deamination patterns, using the output misincorporation frequency estimates of [MapDamage](https://github.com/ginolhac/mapDamage.git).
-
-![Build-Ubuntu](https://github.com/MaelLefeuvre/pmd-mask/workflows/Ubuntu/badge.svg) | ![Build-Ubuntu](https://github.com/MaelLefeuvre/pmd-mask/workflows/MacOS/badge.svg)
+**Ubuntu:** ![Ubuntu](https://github.com/MaelLefeuvre/pmd-mask/actions/workflows/Ubuntu.yml/badge.svg) | **MacOS:** ![MacOS](https://github.com/MaelLefeuvre/pmd-mask/actions/workflows/MacOS.yml/badge.svg)
 
 
 # Installation


### PR DESCRIPTION
- Splits `.github/workflows/rust.yml` file into two separate workflow `Ubuntu.yml` and `MacOS.yml`
- Updates `README.md` accordingly.